### PR TITLE
Updated Tavily search to restrict to Russia and clarified question to…

### DIFF
--- a/lib/tools/search/providers/tavily.ts
+++ b/lib/tools/search/providers/tavily.ts
@@ -32,7 +32,8 @@ export class TavilySearchProvider extends BaseSearchProvider {
         include_image_descriptions: includeImageDescriptions,
         include_answers: true,
         include_domains: includeDomains,
-        exclude_domains: excludeDomains
+        exclude_domains: excludeDomains,
+        country: "russia"
       })
     })
 


### PR DESCRIPTION
…ol usage

This commit introduces two main changes:

1. Modifies the Tavily search provider to include the `country: "russia"` parameter in the API request. This ensures that search results from Tavily are geographically focused on Russia.

2. Confirmed that the existing agent logic in `lib/agents/researcher.ts` already encourages asking for clarification when your queries are ambiguous or lack detail. No code changes were necessary for this part, as the system prompt guides me to ask clarifying questions when needed.